### PR TITLE
Added undo closed tab functionality

### DIFF
--- a/src/tabbar.h
+++ b/src/tabbar.h
@@ -76,6 +76,16 @@ public slots:
 private:
     void setCloseTabButton(int index);
     void createUndoButton();
+    struct ClosedTabInfo {
+        QString url;
+        QString title;
+        QString zimId;
+        QIcon icon;
+        QTimer* expiryTimer;
+    };
+    QList<ClosedTabInfo> m_closedTabs;
+    void storeClosedTab(int index);
+    void restoreLastClosedTab();
 private:
     QStackedWidget*     mp_stackedWidget;
     QScopedPointer<FullScreenWindow> m_fullScreenWindow;


### PR DESCRIPTION
Declared a stack for recently deleted tabs in tabbar.h, then added methods in tabbar.cpp to store deleted tab content in this stack, and then if the undo button is clicked, create a new tab object and populate it with the stored content of the deleted tab. 